### PR TITLE
Bind cache entries also contain the app marker now

### DIFF
--- a/pi_ldapproxy/bindcache.py
+++ b/pi_ldapproxy/bindcache.py
@@ -23,48 +23,54 @@ class BindCache(object):
         :param timeout: Number of seconds after which the entry is removed from the bind cache
         """
         self.timeout = timeout
-        #: Map of tuples (dn, password) to insertion timestamps (determined using ``reactor.seconds``)
+        #: Map of tuples (dn, app_marker, password) to insertion timestamps (determined using ``reactor.seconds``)
         self._cache = {}
 
-    def add_to_cache(self, dn, password):
+    def add_to_cache(self, dn, app_marker, password):
         """
         Add the credentials to the bind cache. They are automatically removed from the cache after ``self.timeout``
         seconds using the ``reactor.callLater`` mechanism.
         If the credentials are already found in the bind cache, the time until their removal is **not** extended!
         :param dn: user distinguished name
+        :param app_marker: app marker
         :param password: user password
         """
-        item = (dn, password)
+        item = (dn, app_marker, password)
         if item not in self._cache:
             current_time = reactor.seconds()
-            log.info('Adding to bind cache: dn={dn!r}, time={time!r}', dn=dn, time=current_time)
+            log.info('Adding to bind cache: dn={dn!r}, marker={marker!r}, time={time!r}',
+                     dn=dn, marker=app_marker, time=current_time)
             self._cache[item] = current_time
-            self.callLater(self.timeout, self.remove_from_cache, dn, password)
+            self.callLater(self.timeout, self.remove_from_cache, dn, app_marker, password)
         else:
-            log.info('Already in the bind cache: dn={dn!r}', dn=dn)
+            log.info('Already in the bind cache: dn={dn!r}, marker={marker!r}',
+                     dn=dn, marker=app_marker)
 
-    def remove_from_cache(self, dn, password):
+    def remove_from_cache(self, dn, app_marker, password):
         """
         If the given credentials are found in the cache, they are removed.
         If they cannot be found, nothing happens.
         :param dn: user distinguished name
+        :param app_marker: app marker
         :param password: user password
         """
-        item = (dn, password)
+        item = (dn, app_marker, password)
         if item in self._cache:
             del self._cache[item]
-            log.info('Removed from bind cache: dn={dn!r} ({remaining!r} remaining)', dn=dn, remaining=len(self._cache))
+            log.info('Removed from bind cache: dn={dn!r}/marker={marker!r} ({remaining!r} remaining)',
+                     dn=dn, marker=app_marker, remaining=len(self._cache))
         else:
             log.info("Removal from bind cache failed as dn={dn!r} is not cached", dn=dn)
 
-    def is_cached(self, dn, password):
+    def is_cached(self, dn, app_marker, password):
         """
         Determines whether the given credentials are found in the bind cache.
         :param dn: user distinguished name
+        :param app_marker: app marker as string
         :param password: user password
         :return: a boolean
         """
-        item = (dn, password)
+        item = (dn, app_marker, password)
         if item in self._cache:
             current_time = reactor.seconds()
             inserted_time = self._cache[item]
@@ -73,7 +79,8 @@ class BindCache(object):
             if current_time - inserted_time < self.timeout:
                 return True
             else:
-                log.info('Inconsistent bind cache: dn={dn!r}, inserted={inserted!r}, current={current!r}',
-                    dn=dn, inserted=inserted_time, current=current_time,
+                log.info('Inconsistent bind cache: dn={dn!r}, marker={marker!r},'
+                         'inserted={inserted!r}, current={current!r}',
+                    dn=dn, marker=app_marker, inserted=inserted_time, current=current_time,
                 )
         return False

--- a/pi_ldapproxy/realmmapping.py
+++ b/pi_ldapproxy/realmmapping.py
@@ -72,7 +72,7 @@ class RealmMappingStrategy(object):
         """
         Given the distinguished name, determine the realm name or raise RealmMappingError.
         :param dn: DN as string
-        :return: A Deferred which fires the realm name (as a string)
+        :return: A Deferred which fires (app marker, realm name) (as strings)
         """
         raise NotImplementedError()
 
@@ -90,7 +90,7 @@ class StaticMappingStrategy(RealmMappingStrategy):
         self.realm = config['realm']
 
     def resolve(self, dn):
-        return defer.succeed(self.realm)
+        return defer.succeed((self.realm, self.realm))
 
 
 class AppCacheMappingStrategy(RealmMappingStrategy):
@@ -126,7 +126,7 @@ class AppCacheMappingStrategy(RealmMappingStrategy):
         realm = self.mappings.get(marker)
         if realm is None:
             raise RealmMappingError('No mapping for marker={marker!r}'.format(marker=marker))
-        return defer.succeed(realm)
+        return defer.succeed((marker, realm))
 
 REALM_MAPPING_STRATEGIES = {
     'static': StaticMappingStrategy,

--- a/pi_ldapproxy/test/test_bindcache.py
+++ b/pi_ldapproxy/test/test_bindcache.py
@@ -7,6 +7,8 @@ from pi_ldapproxy.bindcache import BindCache
 
 DN = 'cn=test,cn=users,dc=test,dc=intranet'
 DN_OTHER = 'cn=other,cn=users,dc=test,dc=intranet'
+APP = 'app1'
+APP_OTHER = 'app2'
 PASSWORD = 'test'
 PASSWORD_OTHER = 'foo'
 
@@ -15,45 +17,47 @@ class BindCacheTest(unittest.TestCase):
         cache = BindCache()
         clock = task.Clock()
         cache.callLater = clock.callLater
-        cache.add_to_cache(DN, PASSWORD)
-        cache.add_to_cache(DN_OTHER, PASSWORD_OTHER)
-        self.assertTrue(cache.is_cached(DN, PASSWORD))
-        self.assertTrue(cache.is_cached(DN_OTHER, PASSWORD_OTHER))
-        self.assertFalse(cache.is_cached(DN_OTHER, PASSWORD))
-        self.assertFalse(cache.is_cached(DN, PASSWORD_OTHER))
+        cache.add_to_cache(DN, APP, PASSWORD)
+        cache.add_to_cache(DN_OTHER, APP_OTHER, PASSWORD_OTHER)
+        self.assertTrue(cache.is_cached(DN, APP, PASSWORD))
+        self.assertTrue(cache.is_cached(DN_OTHER, APP_OTHER, PASSWORD_OTHER))
+        self.assertFalse(cache.is_cached(DN_OTHER, APP, PASSWORD))
+        self.assertFalse(cache.is_cached(DN, APP, PASSWORD_OTHER))
+        self.assertFalse(cache.is_cached(DN_OTHER, APP_OTHER, PASSWORD))
+        self.assertFalse(cache.is_cached(DN, APP_OTHER, PASSWORD_OTHER))
 
     def test_manual_removal(self):
         cache = BindCache()
         clock = task.Clock()
         cache.callLater = clock.callLater
-        cache.add_to_cache(DN, PASSWORD)
-        cache.add_to_cache(DN_OTHER, PASSWORD_OTHER)
-        self.assertTrue(cache.is_cached(DN, PASSWORD))
-        self.assertTrue(cache.is_cached(DN_OTHER, PASSWORD_OTHER))
-        # Remove (DN, PASSWORD)
-        cache.remove_from_cache(DN, PASSWORD)
-        self.assertFalse(cache.is_cached(DN, PASSWORD))
-        self.assertTrue(cache.is_cached(DN_OTHER, PASSWORD_OTHER))
-        # Remove (DN_OTHER, PASSWORD_OTHER)
-        cache.remove_from_cache(DN_OTHER, PASSWORD_OTHER)
-        self.assertFalse(cache.is_cached(DN, PASSWORD))
-        self.assertFalse(cache.is_cached(DN_OTHER, PASSWORD_OTHER))
+        cache.add_to_cache(DN, APP, PASSWORD)
+        cache.add_to_cache(DN_OTHER, APP_OTHER, PASSWORD_OTHER)
+        self.assertTrue(cache.is_cached(DN, APP, PASSWORD))
+        self.assertTrue(cache.is_cached(DN_OTHER, APP_OTHER, PASSWORD_OTHER))
+        # Remove (DN, APP, PASSWORD)
+        cache.remove_from_cache(DN, APP, PASSWORD)
+        self.assertFalse(cache.is_cached(DN, APP, PASSWORD))
+        self.assertTrue(cache.is_cached(DN_OTHER, APP_OTHER, PASSWORD_OTHER))
+        # Remove (DN_OTHER, APP_OTHER, PASSWORD_OTHER)
+        cache.remove_from_cache(DN_OTHER, APP_OTHER, PASSWORD_OTHER)
+        self.assertFalse(cache.is_cached(DN, APP, PASSWORD))
+        self.assertFalse(cache.is_cached(DN_OTHER, APP_OTHER, PASSWORD_OTHER))
         # Remove (DN_OTHER, PASSWORD_OTHER) again
-        cache.remove_from_cache(DN_OTHER, PASSWORD_OTHER)
-        self.assertFalse(cache.is_cached(DN, PASSWORD))
-        self.assertFalse(cache.is_cached(DN_OTHER, PASSWORD_OTHER))
+        cache.remove_from_cache(DN_OTHER, APP_OTHER, PASSWORD_OTHER)
+        self.assertFalse(cache.is_cached(DN, APP, PASSWORD))
+        self.assertFalse(cache.is_cached(DN_OTHER, APP_OTHER, PASSWORD_OTHER))
 
     def test_automatic_removal(self):
         clock = task.Clock()
         cache = BindCache(2)
         cache.callLater = clock.callLater
         # Add and wait a second, it should still be there
-        cache.add_to_cache(DN, PASSWORD)
+        cache.add_to_cache(DN, APP, PASSWORD)
         clock.advance(1)
-        self.assertTrue(cache.is_cached(DN, PASSWORD))
+        self.assertTrue(cache.is_cached(DN, APP, PASSWORD))
         # Wait another two seconds, it should not be there anymore
         clock.advance(2)
-        self.assertFalse(cache.is_cached(DN, PASSWORD))
+        self.assertFalse(cache.is_cached(DN, APP, PASSWORD))
 
     def test_callLater_failure(self):
         """
@@ -62,9 +66,11 @@ class BindCacheTest(unittest.TestCase):
         cache = BindCache(1)
         cache.callLater = lambda *args, **kwargs: None
         # Add and wait half a second, it should still be there
-        cache.add_to_cache(DN, PASSWORD)
+        cache.add_to_cache(DN, APP, PASSWORD)
         time.sleep(0.5)
-        self.assertTrue(cache.is_cached(DN, PASSWORD))
+        self.assertTrue(cache.is_cached(DN, APP, PASSWORD))
+        self.assertFalse(cache.is_cached(DN, APP_OTHER, PASSWORD))
         # TODO: This is not perfect - find a way to test this without sleeping
         time.sleep(1)
-        self.assertFalse(cache.is_cached(DN, PASSWORD))
+        self.assertFalse(cache.is_cached(DN, APP, PASSWORD))
+        self.assertFalse(cache.is_cached(DN, APP_OTHER, PASSWORD))


### PR DESCRIPTION
This makes it impossible to abuse the bind cache
to authenticate to another app using the same credentials.

Closes #20