### PR TITLE
Add an option to ignore search result references

### DIFF
--- a/deploy/ubuntu-config/proxy.ini
+++ b/deploy/ubuntu-config/proxy.ini
@@ -53,6 +53,11 @@ bind-service-account = false
 # If `bind-service-account` is set to false, but `allow-search` is set to true, only the DNs
 # in `passthrough-binds` will be able to issue search requests.
 allow-search = false
+# Currently, ldaptor does not support result references which will break
+# some apps in combination with AD. This option provides a workaround:
+# If it is set to `true`, the LDAP proxy ignores all LDAP SEARCH result references.
+# However, this means that the app does not receive any LDAP SEARCH references.
+ignore-search-result-references = false
 
 [user-mapping]
 # This setting determines the strategy the LDAP proxy uses to determine the username that is sent to privacyIDEA

--- a/deploy/ubuntu-config/proxy.ini
+++ b/deploy/ubuntu-config/proxy.ini
@@ -53,10 +53,10 @@ bind-service-account = false
 # If `bind-service-account` is set to false, but `allow-search` is set to true, only the DNs
 # in `passthrough-binds` will be able to issue search requests.
 allow-search = false
-# Currently, ldaptor does not support result references which will break
+# Currently, ldaptor does not support SEARCH result references which will break
 # some apps in combination with AD. This option provides a workaround:
 # If it is set to `true`, the LDAP proxy ignores all LDAP SEARCH result references.
-# However, this means that the app does not receive any LDAP SEARCH references.
+# The LDAP Proxy does not send any LDAP SEARCH result references to the application.
 ignore-search-result-references = false
 # By default, the LDAP Proxy rejects anonymous binds. With the following option, it can be configured
 # to forward anonymous binds to the LDAP backend.

--- a/example-proxy.ini
+++ b/example-proxy.ini
@@ -53,6 +53,11 @@ bind-service-account = false
 # If `bind-service-account` is set to false, but `allow-search` is set to true, only the DNs
 # in `passthrough-binds` will be able to issue search requests.
 allow-search = false
+# Currently, ldaptor does not support result references which will break
+# some apps in combination with AD. This option provides a workaround:
+# If it is set to `true`, the LDAP proxy ignores all LDAP SEARCH result references.
+# However, this means that the app does not receive any LDAP SEARCH references.
+ignore-search-result-references = false
 
 [user-mapping]
 # This setting determines the strategy the LDAP proxy uses to determine the username that is sent to privacyIDEA

--- a/example-proxy.ini
+++ b/example-proxy.ini
@@ -53,10 +53,10 @@ bind-service-account = false
 # If `bind-service-account` is set to false, but `allow-search` is set to true, only the DNs
 # in `passthrough-binds` will be able to issue search requests.
 allow-search = false
-# Currently, ldaptor does not support result references which will break
+# Currently, ldaptor does not support SEARCH result references which will break
 # some apps in combination with AD. This option provides a workaround:
 # If it is set to `true`, the LDAP proxy ignores all LDAP SEARCH result references.
-# However, this means that the app does not receive any LDAP SEARCH references.
+# The LDAP Proxy does not send any LDAP SEARCH result references to the application.
 ignore-search-result-references = false
 # By default, the LDAP Proxy rejects anonymous binds. With the following option, it can be configured
 # to forward anonymous binds to the LDAP backend.

--- a/pi_ldapproxy/config.py
+++ b/pi_ldapproxy/config.py
@@ -20,6 +20,7 @@ endpoint = string
 passthrough-binds = force_list
 bind-service-account = boolean(default=False)
 allow-search = boolean(default=False)
+ignore-search-result-references = boolean(default=False)
 
 [service-account]
 dn = string

--- a/pi_ldapproxy/proxy.py
+++ b/pi_ldapproxy/proxy.py
@@ -204,6 +204,13 @@ class TwoFactorAuthenticationProxy(ProxyBase):
                     # reset counter and storage
                     self.search_response_entries = 0
                     self.last_search_response_entry = None
+                elif isinstance(response, pureldap.LDAPSearchResultReference):
+                    if self.factory.ignore_search_result_references:
+                        log.info('Ignoring LDAP SEARCH result reference ...')
+                        return None
+                    else:
+                        log.warn('Possibly sending an invalid LDAP SEARCH result reference, '
+                                 'check the ignore-search-result-reference config option for more details.')
         except Exception, e:
             log.failure("Unhandled error in handleProxiedResponse: {e}", e=e)
             raise
@@ -308,6 +315,7 @@ class ProxyServerFactory(protocol.ServerFactory):
 
         self.allow_search = config['ldap-proxy']['allow-search']
         self.bind_service_account = config['ldap-proxy']['bind-service-account']
+        self.ignore_search_result_references = config['ldap-proxy']['ignore-search-result-references']
 
         user_mapping_strategy = USER_MAPPING_STRATEGIES[config['user-mapping']['strategy']]
         log.info('Using user mapping strategy: {strategy!r}', strategy=user_mapping_strategy)


### PR DESCRIPTION
Add a config option to ignore search result references sent from the LDAP backend.

See #32 