### PR TITLE
Allow connection reuse

### DIFF
--- a/deploy/ubuntu-config/proxy.ini
+++ b/deploy/ubuntu-config/proxy.ini
@@ -53,6 +53,10 @@ bind-service-account = false
 # If `bind-service-account` is set to false, but `allow-search` is set to true, only the DNs
 # in `passthrough-binds` will be able to issue search requests.
 allow-search = false
+# By default, the LDAP proxy only allows one bind request per connection. For some apps, this may
+# be sufficient. However, other apps may reuse a LDAP connection and thus require setting this
+# configuration option.
+allow-connection-reuse = false
 
 [user-mapping]
 # This setting determines the strategy the LDAP proxy uses to determine the username that is sent to privacyIDEA

--- a/example-proxy.ini
+++ b/example-proxy.ini
@@ -53,6 +53,10 @@ bind-service-account = false
 # If `bind-service-account` is set to false, but `allow-search` is set to true, only the DNs
 # in `passthrough-binds` will be able to issue search requests.
 allow-search = false
+# By default, the LDAP proxy only allows one bind request per connection. For some apps, this may
+# be sufficient. However, other apps may reuse a LDAP connection and thus require setting this
+# configuration option.
+allow-connection-reuse = false
 
 [user-mapping]
 # This setting determines the strategy the LDAP proxy uses to determine the username that is sent to privacyIDEA

--- a/pi_ldapproxy/config.py
+++ b/pi_ldapproxy/config.py
@@ -20,6 +20,7 @@ endpoint = string
 passthrough-binds = force_list
 bind-service-account = boolean(default=False)
 allow-search = boolean(default=False)
+allow-connection-reuse = boolean(default=False)
 
 [service-account]
 dn = string

--- a/pi_ldapproxy/proxy.py
+++ b/pi_ldapproxy/proxy.py
@@ -37,8 +37,8 @@ VALIDATE_URL_TEMPLATE = '{}validate/check'
 class TwoFactorAuthenticationProxy(ProxyBase):
     def __init__(self):
         ProxyBase.__init__(self)
-        #: Specifies whether we have sent a bind request to the LDAP backend at some point
-        self.bound = False
+        #: Specifies whether we have received a Bind Request at some point
+        self.received_bind_request = False
         #: Specifies whether we forwarded a Bind Request to the LDAP backend because the
         #: DN was found in passthrough_binds.
         self.forwarded_passthrough_bind = False
@@ -138,7 +138,6 @@ class TwoFactorAuthenticationProxy(ProxyBase):
             # Reset value in case the connection is re-used
             self.forwarded_passthrough_bind = False
             yield self.bind_service_account()
-            self.bound = True
         defer.returnValue(result)
 
     def send_bind_response(self, result, request, reply):
@@ -218,11 +217,17 @@ class TwoFactorAuthenticationProxy(ProxyBase):
         :return:
         """
         if isinstance(request, pureldap.LDAPBindRequest):
-            if self.bound:
-                log.warn('Rejected a second bind request in the same connection')
-                self.send_bind_response((False, 'Reusing connections currently unsupported.'), request, reply)
-                return None
-            elif request.dn == '':
+            if self.received_bind_request:
+                # We have already received a bind request in this connection!
+                if self.factory.allow_connection_reuse:
+                    # We need to reset the state before further processing the request
+                    assert False
+                else:
+                    log.warn('Rejected a second bind request in the same connection')
+                    self.send_bind_response((False, 'Reusing connections currently unsupported.'), request, reply)
+                    return None
+            self.received_bind_request = True
+            if request.dn == '':
                 self.send_bind_response((False, 'Anonymous binds are not supported.'), request, reply)
                 return None
             elif self.factory.is_dn_blacklisted(request.dn):
@@ -230,7 +235,6 @@ class TwoFactorAuthenticationProxy(ProxyBase):
                 return None
             elif request.dn in self.factory.passthrough_binds:
                 log.info('BindRequest for {dn!r}, passing through ...', dn=request.dn)
-                self.bound = True
                 self.forwarded_passthrough_bind = True
                 return request, controls
             else:
@@ -251,10 +255,9 @@ class TwoFactorAuthenticationProxy(ProxyBase):
             # Assuming `bind-service-account` is enabled and the privacyIDEA authentication was successful,
             # the service account is already authenticated for `self.client`.
             return request, controls
-        elif isinstance(request, pureldap.LDAPUnbindRequest) and self.bound:
-            # If we have sent a bind request to the LDAP backend in the past, we will forward
-            # the incoming unbind request.
-            # TODO: What if we receive multiple unbind requests?
+        elif isinstance(request, pureldap.LDAPUnbindRequest):
+            # We just forward any Unbind Request, regardless of whether we have sent a Bind Request to
+            # the LDAP backend earlier.
             return request, controls
         else:
             log.info("{class_!r} received, rejecting.", class_=request.__class__.__name__)
@@ -308,6 +311,7 @@ class ProxyServerFactory(protocol.ServerFactory):
 
         self.allow_search = config['ldap-proxy']['allow-search']
         self.bind_service_account = config['ldap-proxy']['bind-service-account']
+        self.allow_connection_reuse = config['ldap-proxy']['allow-connection-reuse']
 
         user_mapping_strategy = USER_MAPPING_STRATEGIES[config['user-mapping']['strategy']]
         log.info('Using user mapping strategy: {strategy!r}', strategy=user_mapping_strategy)

--- a/pi_ldapproxy/proxy.py
+++ b/pi_ldapproxy/proxy.py
@@ -233,8 +233,9 @@ class TwoFactorAuthenticationProxy(ProxyBase):
                     log.info('Reusing LDAP connection, resetting state ...')
                     self.reset_state()
                 else:
-                    log.warn('Rejected a second bind request in the same connection')
-                    self.send_bind_response((False, 'Reusing connections currently unsupported.'), request, reply)
+                    log.warn('Rejected a second bind request in the same connection. '
+                             'Please check the `allow-connection-reuse` config option.')
+                    self.send_bind_response((False, 'Reusing connections is disabled.'), request, reply)
                     return None
             self.received_bind_request = True
             if request.dn == '':

--- a/pi_ldapproxy/test/test_proxy_bind_cache.py
+++ b/pi_ldapproxy/test/test_proxy_bind_cache.py
@@ -33,14 +33,13 @@ class TestProxyUserBind(ProxyTestCase):
         dn = 'uid=hugo,cn=users,dc=test,dc=local'
         server, client = self.create_server_and_client([
             pureldap.LDAPBindResponse(resultCode=0), # for service account
-        ],
-        [
-            pureldap.LDAPBindResponse(resultCode=0),  # for service account
-        ],
-        )
+        ])
         yield client.bind(dn, 'secret')
         time.sleep(0.5)
-        yield client.bind(dn, 'secret')
+        server2, client2 = self.create_server_and_client([
+            pureldap.LDAPBindResponse(resultCode=0),  # for service account
+        ])
+        yield client2.bind(dn, 'secret')
         # but only one authentication request to privacyIDEA!
         self.assertEqual(self.privacyidea.authentication_requests,
                          [('hugo', 'default', 'secret', True)])
@@ -51,14 +50,13 @@ class TestProxyUserBind(ProxyTestCase):
         dn = 'uid=hugo,cn=users,dc=test,dc=local'
         server, client = self.create_server_and_client([
             pureldap.LDAPBindResponse(resultCode=0), # for service account
-        ],
-        [
-            pureldap.LDAPBindResponse(resultCode=0),  # for service account
-        ],
-        )
+        ])
         yield client.bind(dn, 'secret')
         time.sleep(3) # which cleans the bind cache
-        yield client.bind(dn, 'secret')
+        server2, client2 = self.create_server_and_client([
+            pureldap.LDAPBindResponse(resultCode=0),  # for service account
+        ])
+        yield client2.bind(dn, 'secret')
         # two authentication requests to privacyIDEA!
         self.assertEqual(self.privacyidea.authentication_requests,
                          [('hugo', 'default', 'secret', True),
@@ -70,14 +68,13 @@ class TestProxyUserBind(ProxyTestCase):
         dn = 'uid=hugo,cn=users,dc=test,dc=local'
         server, client = self.create_server_and_client([
             pureldap.LDAPBindResponse(resultCode=0), # for service account
-        ],
-        [
-            pureldap.LDAPBindResponse(resultCode=0),  # for service account
-        ],
-        )
+        ])
         yield client.bind(dn, 'secret')
         time.sleep(0.5)
-        d = client.bind(dn, 'something-else')
+        server2, client2 = self.create_server_and_client([
+            pureldap.LDAPBindResponse(resultCode=0), # for service account
+        ])
+        d = client2.bind(dn, 'something-else')
         yield self.assertFailure(d, ldaperrors.LDAPInvalidCredentials)
         # two authentication requests to privacyIDEA!
         self.assertEqual(self.privacyidea.authentication_requests,
@@ -90,14 +87,13 @@ class TestProxyUserBind(ProxyTestCase):
         dn = 'uid=hugo,cn=users,dc=test,dc=local'
         server, client = self.create_server_and_client([
             pureldap.LDAPBindResponse(resultCode=0), # for service account
-        ],
-        [
-            pureldap.LDAPBindResponse(resultCode=0),  # for service account
-        ],
-        )
+        ])
         yield client.bind(dn, 'secret')
         time.sleep(0.5)
-        d = client.bind(dn, 'something-else')
+        server2, client2 = self.create_server_and_client([
+            pureldap.LDAPBindResponse(resultCode=0), # for service account
+        ])
+        d = client2.bind(dn, 'something-else')
         yield self.assertFailure(d, ldaperrors.LDAPInvalidCredentials)
         # two authentication requests to privacyIDEA!
         self.assertEqual(self.privacyidea.authentication_requests,
@@ -110,18 +106,17 @@ class TestProxyUserBind(ProxyTestCase):
         dn = 'uid=hugo,cn=users,dc=test,dc=local'
         server, client = self.create_server_and_client([
             pureldap.LDAPBindResponse(resultCode=0), # for service account
-        ],
-        [
-            pureldap.LDAPBindResponse(resultCode=0),  # for service account
-        ],
-        )
+        ])
         yield client.bind(dn, 'secret')
         time.sleep(0.5)
+        server2, client2 = self.create_server_and_client([
+            pureldap.LDAPBindResponse(resultCode=0),  # for service account
+        ])
         # Monkey-patch the realm mapper (this is suboptimal)
         _old_resolve = self.factory.realm_mapper.resolve
         # Model a second app which maps to the same realm
         self.factory.realm_mapper.resolve = lambda dn: defer.succeed(('other-app', 'default'))
-        yield client.bind(dn, 'secret')
+        yield client2.bind(dn, 'secret')
         # two authentication requests to privacyIDEA!
         # this means that the second request was not taken from the bind cache
         self.assertEqual(self.privacyidea.authentication_requests,

--- a/pi_ldapproxy/test/test_proxy_simple.py
+++ b/pi_ldapproxy/test/test_proxy_simple.py
@@ -144,3 +144,55 @@ class TestProxyReuse(ProxyTestCase):
             pureldap.LDAPBindRequest(dn='uid=service,cn=users,dc=test,dc=local', auth='service-secret'),
             pureldap.LDAPBindRequest(dn='uid=service,cn=users,dc=test,dc=local', auth='service-secret'),
         )
+
+class TestProxyReuseNoServiceBind(ProxyTestCase):
+    additional_config = {
+        'ldap-proxy': {
+            'allow-connection-reuse': True,
+            'bind-service-account': False,
+            'allow-search': True,
+        }
+    }
+    privacyidea_credentials = {
+        'hugo@default': 'secret'
+    }
+
+    @defer.inlineCallbacks
+    def test_state_reset(self):
+        # Passthrough Bind, User Bind
+        dn = 'uid=hugo,cn=users,dc=test,dc=local'
+        search_response = pureldap.LDAPSearchResultEntry(dn, [('someattr', ['somevalue'])])
+        server, client = self.create_server_and_client(
+            [
+                pureldap.LDAPBindResponse(resultCode=0)
+            ],
+            [
+                 search_response,
+                 pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode),
+            ],
+            [
+                pureldap.LDAPBindResponse(resultCode=0)
+            ]
+        )
+        yield client.bind('uid=passthrough,cn=users,dc=test,dc=local', 'some-secret')
+        server.client.assertSent(
+            pureldap.LDAPBindRequest(dn='uid=passthrough,cn=users,dc=test,dc=local', auth='some-secret'),
+        )
+        # perform a search
+        entry = LDAPEntry(client, dn)
+        r = yield entry.search('(|(objectClass=*)(objectcLAsS=App-markerSecret))', scope=pureldap.LDAP_SCOPE_baseObject)
+        # check that the state is correct
+        self.assertTrue(server.received_bind_request)
+        self.assertTrue(server.forwarded_passthrough_bind)
+        self.assertEqual(server.search_response_entries, 0)
+        self.assertIsNone(server.last_search_response_entry)
+        yield client.bind(dn, 'secret')
+        self.assertEqual(len(server.client.sent), 2)
+        # Check that the bind requests was sent properly
+        self.assertEqual(server.client.sent[0],
+                         pureldap.LDAPBindRequest(dn='uid=passthrough,cn=users,dc=test,dc=local', auth='some-secret'))
+        # check that state is properly reset
+        self.assertTrue(server.received_bind_request)
+        self.assertFalse(server.forwarded_passthrough_bind)
+        self.assertEqual(server.search_response_entries, 0)
+        self.assertIsNone(server.last_search_response_entry)


### PR DESCRIPTION
Up until now, we explicitly disallowed multiple bind requests per LDAP connection. This implements proper support for it.

This also modifies the LDAP proxy behavior with unbind requests: Previously, we only forwarded unbind requests to the LDAP backend if we had sent a bind request before. Now, we just forward unbind requests in any case.

Fixes #30