### PR TITLE
proxy: Pass through compare requests

### DIFF
--- a/pi_ldapproxy/proxy.py
+++ b/pi_ldapproxy/proxy.py
@@ -294,7 +294,7 @@ class TwoFactorAuthenticationProxy(ProxyBase):
             # Assuming `bind-service-account` is enabled and the privacyIDEA authentication was successful,
             # the service account is already authenticated for `self.client`.
             return request, controls
-        elif isinstance(request, pureldap.LDAPUnbindRequest):
+        elif isinstance(request, pureldap.LDAPUnbindRequest) or isinstance(request, pureldap.LDAPCompareRequest):
             # We just forward any Unbind Request, regardless of whether we have sent a Bind Request to
             # the LDAP backend earlier.
             return request, controls


### PR DESCRIPTION
These are e.g. used by Django's LDAP integration[1] and thus needed when
implementing LDAP support for e.g. mailman with privacyidea as auth
source.

[1] https://github.com/django-auth-ldap/django-auth-ldap/blob/fe23ab46da33828f92c6aff3ce73a7bd1c806ca7/django_auth_ldap/config.py#L503-L518